### PR TITLE
Fix scheduled PDF generation failing with Puppeteer EACCES

### DIFF
--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -4,6 +4,19 @@ pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/supervisor
 nodaemon=true
 user=root
+; Children run as www-data but inherit supervisord's env. Force a writable
+; HOME so Puppeteer/cosmiconfig doesn't stat /root/.config/puppeteer (EACCES).
+environment=HOME="/var/www/html/storage",XDG_CONFIG_HOME="/var/www/html/storage"
+
+[unix_http_server]
+file=/run/supervisord.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock
 
 [include]
 files = /etc/supervisor/conf.d/*.conf

--- a/routes/console.php
+++ b/routes/console.php
@@ -14,10 +14,12 @@ Artisan::command('inspire', function () {
 |--------------------------------------------------------------------------
 */
 
-// Archive the current day's PDF at 23:59 on weekdays
+// Archive the current day's PDF at 23:59 on weekdays.
+// Output is logged (not ->runInBackground()) so failures are visible in
+// storage/logs/schedule-pdf.log instead of being silently discarded.
 Schedule::command('pdf:generate today')
     ->weekdays()
     ->at('23:59')
-    ->withoutOverlapping()
+    ->withoutOverlapping(10)
     ->onOneServer()
-    ->runInBackground();
+    ->appendOutputTo(storage_path('logs/schedule-pdf.log'));


### PR DESCRIPTION
The scheduler ran correctly every cycle but pdf:generate failed every time: supervisord runs as root (HOME=/root), and the scheduler program, though dropping to www-data, inherited HOME=/root. Puppeteer/cosmiconfig then stat()s $HOME/.config/puppeteer -> /root/.config/puppeteer, which www-data cannot access (EACCES), so Chromium never launched and no PDF was produced. ->runInBackground() silently discarded the error.

- supervisord.conf: set a writable HOME/XDG_CONFIG_HOME for all child processes (fixes scheduler and the php-fpm web export path); add the missing unix_http_server/rpcinterface/supervisorctl sections so supervisorctl works.
- console.php: replace ->runInBackground() with ->appendOutputTo() and shorten the overlap lock so failures are logged instead of swallowed and a hung run cannot block the daily job for 24h.