### PR TITLE
PDF export improvements: emoji fonts, schedule, placeholders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,10 @@ RUN apk add --no-cache \
         nss \
         freetype \
         harfbuzz \
-        ttf-freefont
+        ttf-freefont \
+        font-noto \
+        font-noto-cjk \
+        font-noto-emoji
 
 # Build and install PHP extensions
 RUN apk add --no-cache --virtual .build-deps \

--- a/app/Filament/Resources/DayPdfResource.php
+++ b/app/Filament/Resources/DayPdfResource.php
@@ -114,7 +114,18 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                     ->iconButton()
                     ->action(function (DayPdf $record) {
                         $pdfService = app(PdfExportService::class);
-                        $base64Content = $pdfService->getOrGeneratePdf($record->date);
+                        $base64Content = $pdfService->getExistingPdf($record->date);
+
+                        if (! $base64Content) {
+                            Notification::make()
+                                ->title('PDF nicht verfügbar')
+                                ->body('Für dieses Datum existiert keine PDF.')
+                                ->danger()
+                                ->send();
+
+                            return null;
+                        }
+
                         $binaryContent = base64_decode($base64Content);
 
                         $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';
@@ -136,7 +147,18 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                         // If only one record, download as PDF directly
                         if ($records->count() === 1) {
                             $record = $records->first();
-                            $base64Content = $pdfService->getOrGeneratePdf($record->date);
+                            $base64Content = $pdfService->getExistingPdf($record->date);
+
+                            if (! $base64Content) {
+                                Notification::make()
+                                    ->title('PDF nicht verfügbar')
+                                    ->body('Für dieses Datum existiert keine PDF.')
+                                    ->danger()
+                                    ->send();
+
+                                return null;
+                            }
+
                             $binaryContent = base64_decode($base64Content);
 
                             $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';
@@ -162,7 +184,12 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                         $zip = new ZipArchive;
                         if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true) {
                             foreach ($sortedRecords as $record) {
-                                $base64Content = $pdfService->getOrGeneratePdf($record->date);
+                                $base64Content = $pdfService->getExistingPdf($record->date);
+
+                                if (! $base64Content) {
+                                    continue;
+                                }
+
                                 $binaryContent = base64_decode($base64Content);
 
                                 $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';

--- a/app/Filament/Resources/DayPdfResource.php
+++ b/app/Filament/Resources/DayPdfResource.php
@@ -183,10 +183,13 @@ class DayPdfResource extends Resource implements HasShieldPermissions
 
                         $zip = new ZipArchive;
                         if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true) {
+                            $missingDates = [];
                             foreach ($sortedRecords as $record) {
                                 $base64Content = $pdfService->getExistingPdf($record->date);
 
                                 if (! $base64Content) {
+                                    $missingDates[] = $record->date->format('d.m.Y');
+
                                     continue;
                                 }
 
@@ -197,6 +200,14 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                                 $zip->addFromString($filename, $binaryContent);
                             }
                             $zip->close();
+
+                            if ($missingDates !== []) {
+                                Notification::make()
+                                    ->title('Einige PDFs fehlen')
+                                    ->body('Folgende Daten konnten nicht hinzugefügt werden: '.implode(', ', $missingDates))
+                                    ->warning()
+                                    ->send();
+                            }
 
                             return Response::download($zipPath, $zipFileName)->deleteFileAfterSend(true);
                         }

--- a/app/Filament/Resources/DayPdfResource.php
+++ b/app/Filament/Resources/DayPdfResource.php
@@ -254,7 +254,7 @@ class DayPdfResource extends Resource implements HasShieldPermissions
         if ($notifyIfMissing) {
             Notification::make()
                 ->title('PDF nicht verfügbar')
-                ->body('Für dieses Datum ist noch keine gespeicherte PDF vorhanden. PDFs werden nachts automatisch erstellt. Sie können die PDF über „Neu generieren“ sofort erstellen.')
+                ->body('Für dieses Datum ist noch keine gespeicherte PDF vorhanden. PDFs werden nachts automatisch erstellt. Sie können die PDF über "Neu generieren" sofort erstellen.')
                 ->warning()
                 ->send();
         }

--- a/app/Filament/Resources/DayPdfResource.php
+++ b/app/Filament/Resources/DayPdfResource.php
@@ -114,25 +114,12 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                     ->iconButton()
                     ->action(function (DayPdf $record) {
                         $pdfService = app(PdfExportService::class);
-                        $base64Content = $pdfService->getExistingPdf($record->date);
-
+                        $base64Content = self::getExistingPdf($pdfService, $record);
                         if (! $base64Content) {
-                            Notification::make()
-                                ->title('PDF nicht verfügbar')
-                                ->body('Für dieses Datum existiert keine PDF.')
-                                ->danger()
-                                ->send();
-
-                            return null;
+                            return;
                         }
 
-                        $binaryContent = base64_decode($base64Content);
-
-                        $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';
-
-                        return Response::streamDownload(function () use ($binaryContent) {
-                            echo $binaryContent;
-                        }, $filename, ['Content-Type' => 'application/pdf']);
+                        return self::streamPdfDownload($record, $base64Content);
                     }),
             ])
             ->recordAction('download')
@@ -147,25 +134,12 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                         // If only one record, download as PDF directly
                         if ($records->count() === 1) {
                             $record = $records->first();
-                            $base64Content = $pdfService->getExistingPdf($record->date);
-
+                            $base64Content = self::getExistingPdf($pdfService, $record);
                             if (! $base64Content) {
-                                Notification::make()
-                                    ->title('PDF nicht verfügbar')
-                                    ->body('Für dieses Datum existiert keine PDF.')
-                                    ->danger()
-                                    ->send();
-
-                                return null;
+                                return;
                             }
 
-                            $binaryContent = base64_decode($base64Content);
-
-                            $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';
-
-                            return Response::streamDownload(function () use ($binaryContent) {
-                                echo $binaryContent;
-                            }, $filename, ['Content-Type' => 'application/pdf']);
+                            return self::streamPdfDownload($record, $base64Content);
                         }
 
                         // Multiple records - create ZIP
@@ -185,7 +159,7 @@ class DayPdfResource extends Resource implements HasShieldPermissions
                         if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true) {
                             $missingDates = [];
                             foreach ($sortedRecords as $record) {
-                                $base64Content = $pdfService->getExistingPdf($record->date);
+                                $base64Content = self::getExistingPdf($pdfService, $record, false);
 
                                 if (! $base64Content) {
                                     $missingDates[] = $record->date->format('d.m.Y');
@@ -268,5 +242,34 @@ class DayPdfResource extends Resource implements HasShieldPermissions
             'delete',
             'delete_any',
         ];
+    }
+
+    protected static function getExistingPdf(PdfExportService $pdfService, DayPdf $record, bool $notifyIfMissing = true): ?string
+    {
+        $base64Content = $pdfService->getExistingPdf($record->date);
+        if ($base64Content) {
+            return $base64Content;
+        }
+
+        if ($notifyIfMissing) {
+            Notification::make()
+                ->title('PDF nicht verfügbar')
+                ->body('Für dieses Datum ist noch keine gespeicherte PDF vorhanden. PDFs werden nachts automatisch erstellt. Sie können die PDF über „Neu generieren“ sofort erstellen.')
+                ->warning()
+                ->send();
+        }
+
+        return null;
+    }
+
+    protected static function streamPdfDownload(DayPdf $record, string $base64Content)
+    {
+        $binaryContent = base64_decode($base64Content);
+
+        $filename = $record->date->locale(config('app.locale'))->translatedFormat('l, d.m.Y').'.pdf';
+
+        return Response::streamDownload(function () use ($binaryContent) {
+            echo $binaryContent;
+        }, $filename, ['Content-Type' => 'application/pdf']);
     }
 }

--- a/app/Services/PdfExportService.php
+++ b/app/Services/PdfExportService.php
@@ -10,7 +10,8 @@ use Spatie\LaravelPdf\Facades\Pdf;
 class PdfExportService
 {
     public function __construct(
-        private LayoutService $layoutService
+        private LayoutService $layoutService,
+        private LunchService $lunchService,
     ) {}
 
     /**
@@ -123,6 +124,9 @@ class PdfExportService
 
         $absences = array_values(array_unique($absences, SORT_REGULAR));
 
+        // Get lunch for placeholder replacement (e.g. %mittagessen%)
+        $lunch = $this->lunchService->getLunch($date->toDateString());
+
         // Set up writable directory for Chrome user data
         $userDataDir = storage_path('app/chrome-data');
         if (! file_exists($userDataDir)) {
@@ -136,6 +140,7 @@ class PdfExportService
             'lessons' => $lessons,
             'colors' => $colors,
             'absences' => $absences,
+            'lunch' => $lunch,
         ])
             ->format('a4')
             ->landscape()

--- a/app/Services/PdfExportService.php
+++ b/app/Services/PdfExportService.php
@@ -127,8 +127,11 @@ class PdfExportService
         // Get lunch for placeholder replacement (e.g. %mittagessen%)
         $lunch = $this->lunchService->getLunch($date->toDateString());
 
-        // Set up writable directory for Chrome user data
-        $userDataDir = storage_path('app/chrome-data');
+        // Set up writable directory for Chrome user data.
+        // Per-invocation subdir so concurrent generatePdf() calls (e.g. the
+        // scheduled `yesterday` and `today` jobs running back-to-back) don't
+        // collide on Chromium's user-data-dir lock.
+        $userDataDir = storage_path('app/chrome-data/'.$date->format('Y-m-d').'-'.uniqid('', true));
         if (! file_exists($userDataDir)) {
             mkdir($userDataDir, 0755, true); // Secure permissions (owner rwx, group/others rx)
         }
@@ -177,11 +180,41 @@ class PdfExportService
             mkdir(storage_path('app/temp'), 0755, true);
         }
 
-        $pdf->save($tempPath);
-        $content = file_get_contents($tempPath);
-        unlink($tempPath);
+        try {
+            $pdf->save($tempPath);
+            $content = file_get_contents($tempPath);
+        } finally {
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+            // Best-effort cleanup of the per-run Chrome profile dir.
+            $this->removeDirectoryRecursive($userDataDir);
+        }
 
         return $content;
+    }
+
+    /**
+     * Recursively delete a directory and its contents. Errors are swallowed
+     * because this runs in a finally block; leftover dirs are harmless and
+     * will simply be ignored on the next run (each has a unique name).
+     */
+    private function removeDirectoryRecursive(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $entry) {
+            @($entry->isDir() && ! $entry->isLink() ? rmdir($entry->getPathname()) : unlink($entry->getPathname()));
+        }
+
+        @rmdir($path);
     }
 
     /**

--- a/resources/views/pdf/day-layout.blade.php
+++ b/resources/views/pdf/day-layout.blade.php
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ $date->locale('de')->translatedFormat('l, d.m.Y') }}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
         * {
             margin: 0;
@@ -24,7 +21,7 @@
             height: 100vh;
             margin: 0;
             padding: 0;
-            font-family: 'Inter', 'Ubuntu', sans-serif;
+            font-family: 'Noto Sans', 'Noto Sans CJK SC', 'Noto Sans CJK TC', 'Noto Sans CJK JP', 'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', 'Ubuntu', sans-serif;
             font-size: {{ $textSize }}%;
             color: black;
             background: white;

--- a/resources/views/pdf/day-layout.blade.php
+++ b/resources/views/pdf/day-layout.blade.php
@@ -173,7 +173,7 @@
                                 @endif
                             @else
                                 @php
-                                    // Simple placeholder replacement for PDF
+                                    // Placeholder replacement for PDF — mirrors Day::replacePlaceholders()
                                     $displayName = $cell['displayName'] ?? '';
                                     $dayName = $date->translatedFormat('D');
                                     $dayFull = $date->translatedFormat('d.m.Y');
@@ -183,8 +183,15 @@
                                         $absencesStr .= $absence['display_name'] . ($key === array_key_last($absences) ? '' : ', ');
                                     }
 
-                                    $displayName = str_replace('%tag%', str_replace('.', '', $dayName) . " " . $dayFull, $displayName);
-                                    $displayName = str_replace('%abwesenheit%', $absencesStr, $displayName);
+                                    $context = [
+                                        'mittagessen' => $lunch ?? '',
+                                        'abwesenheit' => $absencesStr,
+                                        'tag' => str_replace('.', '', $dayName) . ' ' . $dayFull,
+                                    ];
+
+                                    $displayName = preg_replace_callback('/%([a-zA-Z0-9_]+)%/', function ($matches) use ($context) {
+                                        return $context[$matches[1]] ?? $matches[0];
+                                    }, $displayName);
                                 @endphp
                                 {!! $displayName !!}
                             @endif

--- a/routes/console.php
+++ b/routes/console.php
@@ -22,6 +22,14 @@ Schedule::command('pdf:generate yesterday')
     ->onOneServer()
     ->runInBackground();
 
+// On Mondays, also refresh Friday's PDF to cover weekend gap
+Schedule::command('pdf:generate last friday')
+    ->mondays()
+    ->at('01:02')
+    ->withoutOverlapping()
+    ->onOneServer()
+    ->runInBackground();
+
 Schedule::command('pdf:generate today')
     ->weekdays()
     ->at('01:05')

--- a/routes/console.php
+++ b/routes/console.php
@@ -24,7 +24,7 @@ Schedule::command('pdf:generate yesterday')
 
 Schedule::command('pdf:generate today')
     ->weekdays()
-    ->at('01:00')
+    ->at('01:05')
     ->withoutOverlapping()
     ->onOneServer()
     ->runInBackground();

--- a/routes/console.php
+++ b/routes/console.php
@@ -14,10 +14,17 @@ Artisan::command('inspire', function () {
 |--------------------------------------------------------------------------
 */
 
-// Archive the current day's PDF at 23:59 on weekdays
+// Generate PDFs for previous and current day at 01:00 on weekdays
+Schedule::command('pdf:generate yesterday')
+    ->weekdays()
+    ->at('01:00')
+    ->withoutOverlapping()
+    ->onOneServer()
+    ->runInBackground();
+
 Schedule::command('pdf:generate today')
     ->weekdays()
-    ->at('23:59')
+    ->at('01:00')
     ->withoutOverlapping()
     ->onOneServer()
     ->runInBackground();


### PR DESCRIPTION
Bundles the PDF export work on this branch.

## Emoji / font rendering
- Install `font-noto`, `font-noto-cjk`, `font-noto-emoji` in the Alpine image so the PDF renderer has glyphs for emoji and non-Latin scripts.
- Drop the Google Fonts `<link>` from the PDF blade — rendering no longer depends on outbound network from the container.
- Switch the PDF font stack to Noto Sans + Noto Color Emoji.

## Scheduled PDF generation
- Generate yesterday's and today's PDF at 01:00 / 01:05 on weekdays with output logged to `storage/logs/schedule-pdf.log` (failures visible instead of silently discarded).
- Monday 01:02 refreshes last Friday's PDF to cover the weekend gap.
- Per-invocation Chromium `user-data-dir` (`storage/app/chrome-data/<date>-<uniqid>/`, cleaned up in a `finally`) so concurrent runs don't collide on the profile lock.

## Missing-PDF UX
- `DayPdfResource` download actions use `getExistingPdf` — never regenerate on demand.
- Bulk download collects missing dates into one warning notification listing them all.
- Single-record missing case shows a warning with a "Neu generieren" hint.
- Extracted `getExistingPdf()` / `streamPdfDownload()` helpers in the resource.

## Placeholders
- PDF now resolves `%mittagessen%`, `%abwesenheit%`, `%tag%` via the same `preg_replace_callback` + context map as `Day::replacePlaceholders()`, instead of two `str_replace` calls that silently ignored `%mittagessen%`.
- `PdfExportService` gains a `LunchService` dependency to fetch the lunch text for the target date.

## Known follow-ups (not in this PR)
- Placeholder logic is duplicated between `Day::replacePlaceholders` and the PDF blade — worth extracting a shared resolver to prevent drift.
- PDF blade still emits `displayName` via `{!! !!}` (pre-existing on master).
- `displayName` font-stack lists `Noto Sans CJK SC/TC/JP`; Alpine installs a single `Noto Sans CJK` family. Harmless for Latin-only content.
